### PR TITLE
added http strict transport security for pci-compliance

### DIFF
--- a/src/assets/nginx.yaml
+++ b/src/assets/nginx.yaml
@@ -4,9 +4,9 @@ files:
         owner: root
         group: users
         content: |
-          proxy_buffer_size   128k;
-          proxy_buffers   4 256k;
-          proxy_busy_buffers_size   256k;
+          proxy_buffer_size 128k;
+          proxy_buffers 4 256k;
+          proxy_busy_buffers_size 256k;
 
           upstream nodejs {
             server 127.0.0.1:8081;
@@ -29,9 +29,10 @@ files:
             }
 
             access_log /var/log/nginx/healthd/application.log.$year-$month-$day-$hour healthd;
-            access_log  /var/log/nginx/access.log  main;
+            access_log /var/log/nginx/access.log main;
+
             <% if(forceSSL) { %>
-            if ($http_x_forwarded_proto = "http") {
+            if ($http_x_forwarded_proto != "https") {
               return 301 https://$host$request_uri;
             }
             <% } %>
@@ -46,25 +47,28 @@ files:
               expires max;
             }
 
-
             location / {
-              proxy_pass  http://nodejs;
-              proxy_set_header   Connection "";
+              proxy_pass http://nodejs;
+              proxy_set_header Connection "";
               proxy_http_version 1.1;
-              proxy_set_header        Host            $host;
-              proxy_set_header        X-Real-IP       $remote_addr;
-              proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
               proxy_set_header Upgrade $http_upgrade;
               proxy_set_header Connection "upgrade";
+
+              <% if(forceSSL) { %>
+              add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
+              <% } %>
             }
 
             location /aws-health-check-3984729847289743128904723 {
-              proxy_pass  http://healthcheck;
-              proxy_set_header   Connection "";
+              proxy_pass http://healthcheck;
+              proxy_set_header Connection "";
               proxy_http_version 1.1;
-              proxy_set_header        Host            $host;
-              proxy_set_header        X-Real-IP       $remote_addr;
-              proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
               proxy_set_header Upgrade $http_upgrade;
               proxy_set_header Connection "upgrade";
             }


### PR DESCRIPTION
This PR adds [HTTP Strict Transport Security](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security), which is currently the only missing security feature of the Nginx-config for [PCI-DSS](https://en.wikipedia.org/wiki/Payment_Card_Industry_Data_Security_Standard)-compliance.

The remaining changes are basically code style formatting. Boy Scout Rule :sunglasses: 