### PR TITLE
fix redirect for health check

### DIFF
--- a/src/assets/nginx.yaml
+++ b/src/assets/nginx.yaml
@@ -32,7 +32,7 @@ files:
             access_log /var/log/nginx/access.log main;
 
             <% if(forceSSL) { %>
-            if ($http_x_forwarded_proto != "https") {
+            if ($http_x_forwarded_proto = "http") {
               return 301 https://$host$request_uri;
             }
             <% } %>


### PR DESCRIPTION
With the last PR, I introduced an issue here. It won't let the ALB healthcheck succeed, because it will try to redirect it.