### PR TITLE
Added support for custom files

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -89,7 +89,7 @@ module.exports = {
         // (optional) Send a SIGTERM signal to the app instances 30 seconds before they will be shut down.
         gracefulShutdown: true,
 
-        // (optional) Supports large environment variables and settings.json by storing them in s3. 
+        // (optional) Supports large environment variables and settings.json by storing them in s3.
         longEnvVars: true,
 
         // (optional, default is 3) Number of old application versions to keep
@@ -107,6 +107,18 @@ module.exports = {
             allowIncompatibleUpdates: true,
             executable: 'meteor'
         },
+
+        // (optional) Add additional files to add to the container.
+        // "content" is a list of lines (strings) in the file.
+        additionalFiles: [
+          {
+            //Adds "mylog.log" to the logs that are tailed and exported in elastic beanstalk
+            filepath: "/opt/elasticbeanstalk/tasks/taillogs.d/mylog.conf",
+            content: [
+              "/var/log/mylog.log*"
+            ]
+          },
+        ]
 
         // (optional) Override or add options in the beanstalk config
         // this plugin creates.You can customize any option on:
@@ -137,7 +149,7 @@ Changes to `yumPackages`, `forceSSL`, `buildOptions`, and `longEnvVars` requires
 - `mup start` Scales the app back up after being stopped
 - `mup restart` Restarts the app
 - `mup beanstalk events` View events from the app's Beanstalk enviroment. Useful when troubleshooting problems.
-- `mup beanstalk clean` Removes old application versions from s3 and Beanstalk. Is automatically run by `mup deploy` 
+- `mup beanstalk clean` Removes old application versions from s3 and Beanstalk. Is automatically run by `mup deploy`
 - `mup beanstalk ssl` Sets up SSL and shows you it's current status. Automatically run by `mup reconfig` and `mup deploy`
 - `mup beanstalk status` View the app's and server's health and http request stats
 
@@ -229,7 +241,7 @@ ACM automatically renews the certificates.
 
 ## Graceful Shutdown
 
-This plugin can setup CloudWatch Events to send a `SIGTERM` signal to your app on instances that are being drained by the load balancer. Your app can listen for this signal and gradually disconnect users or do other work needed before shutting down. The signal is sent at least 30 seconds before before the load balancer finishes draining it. 
+This plugin can setup CloudWatch Events to send a `SIGTERM` signal to your app on instances that are being drained by the load balancer. Your app can listen for this signal and gradually disconnect users or do other work needed before shutting down. The signal is sent at least 30 seconds before before the load balancer finishes draining it.
 
 Before enabling this feature, make sure the IAM user has these policies:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mup-aws-beanstalk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3008,6 +3008,7 @@
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
+          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -3029,7 +3030,8 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -3043,11 +3045,13 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -3058,15 +3062,18 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x"
           }
@@ -3101,7 +3108,8 @@
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -3128,7 +3136,8 @@
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -3237,6 +3246,7 @@
         "hawk": {
           "version": "3.1.3",
           "bundled": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x",
             "cryptiles": "2.x.x",
@@ -3278,6 +3288,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3289,7 +3300,8 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -3352,11 +3364,13 @@
         },
         "mime-db": {
           "version": "1.27.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
+          "optional": true,
           "requires": {
             "mime-db": "~1.27.0"
           }
@@ -3424,7 +3438,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -3473,7 +3488,8 @@
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -3506,6 +3522,7 @@
         "readable-stream": {
           "version": "2.2.9",
           "bundled": true,
+          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -3554,7 +3571,8 @@
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -3574,6 +3592,7 @@
         "sntp": {
           "version": "1.0.9",
           "bundled": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -3604,6 +3623,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3613,6 +3633,7 @@
         "string_decoder": {
           "version": "1.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -3637,6 +3658,7 @@
         "tar": {
           "version": "2.2.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -3686,7 +3708,8 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",

--- a/src/assets/addfiles.yaml
+++ b/src/assets/addfiles.yaml
@@ -1,0 +1,9 @@
+files:
+    <% for(var index in additionalFiles) { %>"<%- additionalFiles[index].filepath %>" :
+        mode: "000775"
+        owner: root
+        group: users
+        content: |
+            <% for(var line in additionalFiles[index].content) { %><%- additionalFiles[index].content[line] %>
+            <% } %>
+    <% } %>

--- a/src/command-handlers.js
+++ b/src/command-handlers.js
@@ -145,12 +145,14 @@ export async function setup(api) {
 
   if (appConfig.gracefulShutdown) {
     logStep('=> Ensuring Graceful Shutdown is setup');
+    const region = appConfig.region || 'us-east-1';
 
-    const existingBucket = findBucketWithPrefix(Buckets, trailBucketPrefix);
+    const regionTrailBucketPrefix = `${trailBucketPrefix}-${region}`;
+
+    const existingBucket = findBucketWithPrefix(Buckets, regionTrailBucketPrefix);
     const trailBucketName = existingBucket ?
       existingBucket.Name :
-      createUniqueName(trailBucketPrefix);
-    const region = appConfig.region || 'us-east-1';
+      createUniqueName(regionTrailBucketPrefix);
     const accountId = await getAccountId();
     const policy = trailBucketPolicy(accountId, trailBucketName);
 

--- a/src/prepare-bundle.js
+++ b/src/prepare-bundle.js
@@ -18,7 +18,8 @@ export function injectFiles(api, name, version, appConfig) {
     forceSSL,
     gracefulShutdown,
     buildOptions,
-    longEnvVars
+    longEnvVars,
+    additionalFiles
   } = appConfig;
   const bundlePath = buildOptions.buildLocation;
   const {
@@ -75,6 +76,12 @@ export function injectFiles(api, name, version, appConfig) {
     copy(sourcePath, destPath, {
       bucketName: bucket
     });
+  }
+
+  if (additionalFiles) {
+    sourcePath = api.resolvePath(__dirname, './assets/addfiles.yaml');
+    destPath = api.resolvePath(bundlePath, 'bundle/.ebextensions/addfiles.config');
+    copy(sourcePath, destPath, { additionalFiles });
   }
 
   sourcePath = api.resolvePath(__dirname, './assets/health-check.js');

--- a/src/validate.js
+++ b/src/validate.js
@@ -32,6 +32,10 @@ const schema = joi.object().keys({
     /[/s/S]*/,
     [joi.string().allow('')]
   ),
+  additionalFiles: joi.array().items(joi.object({
+    filepath: joi.string().trim().required(),
+    content: joi.array().items(joi.string().allow(''))
+  })),
   oldVersions: joi.number(),
   customBeanstalkConfig: joi.array().items(joi.object({
     namespace: joi.string().trim().required(),


### PR DESCRIPTION
Resolves #61 

This will add the ability to inject additional files into the ELB instances, like configuration files and additional scripts that are not configurable through the ELB settings. I've used this successfully to add the Datadog monitoring agent along with config files for it.

```
additionalFiles: [
          {
            //Adds "mylog.log" to the logs that are tailed and exported in elastic beanstalk
            filepath: "/opt/elasticbeanstalk/tasks/taillogs.d/mylog.conf",
            content: [
              "/var/log/mylog.log*"
            ]
          },
] 
```