### PR TITLE
Fix memory leak in health-check.js

### DIFF
--- a/src/assets/health-check.js
+++ b/src/assets/health-check.js
@@ -30,11 +30,12 @@ var server = http.createServer(function (request, response) {
 
   log('Received health check request', true);
 
-  appRequest = http.get('http://127.0.0.1:8081', function () {
+  appRequest = http.get('http://127.0.0.1:8081', function (res) {
     log('Health check succeeded', true);
     response.statusCode = 200;
     response.end('Success');
     clearTimeout(timeout);
+    res.resume();
   }).on('error', function (e) {
     log('Request to app failed ' + e);
     response.statusCode = 500;


### PR DESCRIPTION
As currently written, `health-check.js` leaks a file handle with every request, because it doesn't consume the response to the http request that it makes. The size of this leak varies based on what the application is doing with the handle; in our case, a version upgrade changed the rate of the leak from slow to fast, causing it to bring down our staging servers. Inspection of the degraded servers showed that health-check.js had 2.5k leaked file handles (visible in `lsof`), and `/var/log/messages` contained out-of-memory warnings from the kernel TCP subsystem (which is where the memory is held, if you hold onto a file handle with data buffered in it).