### PR TITLE
Update for Node 14 and Meteor 2.3+

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-src
 tests
 node_modules
 .vscode

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+src
 tests
 node_modules
 .vscode

--- a/src/command-handlers.js
+++ b/src/command-handlers.js
@@ -477,7 +477,12 @@ export async function reconfig(api) {
     const {
       SolutionStacks
     } = await beanstalk.listAvailableSolutionStacks().promise();
-    const solutionStack = SolutionStacks.find(name => name.endsWith('running Node.js'));
+    const bundlePath = config.app.buildOptions.buildLocation;
+    const {
+      nodeVersion
+    } = (0, _utils.getNodeVersion)(api, bundlePath);
+    const majorNodeVersion = nodeVersion.split('.')[0];
+    const solutionStack = SolutionStacks.find(name => name.endsWith(`running Node.js ${majorNodeVersion}`));
 
     const [version] = await ebVersions(api);
     await beanstalk.createEnvironment({


### PR DESCRIPTION
Gets the major Node version used by Meteor and matches it with the AWS Beanstalk solution stack. 

Amazon changed how they name the solution stacks which meant the previous command-handlers.js code would put you on a deprecated Node platform.