### PR TITLE
Update for Node 14 and Meteor 2.3+

### DIFF
--- a/src/command-handlers.js
+++ b/src/command-handlers.js
@@ -32,6 +32,7 @@ import {
   ensurePoliciesAttached,
   ensureBucketPolicyAttached,
   getAccountId,
+  getNodeVersion,
   getLogs,
   logStep,
   names,
@@ -477,7 +478,12 @@ export async function reconfig(api) {
     const {
       SolutionStacks
     } = await beanstalk.listAvailableSolutionStacks().promise();
-    const solutionStack = SolutionStacks.find(name => name.endsWith('running Node.js'));
+    const bundlePath = config.app.buildOptions.buildLocation;
+    const {
+      nodeVersion
+    } = getNodeVersion(api, bundlePath);
+    const majorNodeVersion = nodeVersion.split('.')[0];
+    const solutionStack = SolutionStacks.find(name => name.endsWith(`running Node.js ${majorNodeVersion}`));
 
     const [version] = await ebVersions(api);
     await beanstalk.createEnvironment({


### PR DESCRIPTION
Gets the major Node version used by Meteor and matches it with the AWS Beanstalk solution stack.

Amazon changed how they name the solution stacks which meant the previous command-handlers.js code would put you on a deprecated Node platform.