### PR TITLE
Fixing Permissions names in AWS Setup steps

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,6 +69,7 @@ You can select `Add user to group` and create a new group. The group should have
 - `AWSCertificateManagerFullAccess` Used to create and manage SSL certificates for the app
 - `EC2InstanceConnect` is optional. Used when accessing a production Meteor shell or to connect your node developer tools to the app running in Elastic Beanstalk
 - `AmazonEC2FullAccess`
+- `AmazonS3FullAccess`
 
 In your mup config, set `app.auth.id` to the Access Key ID, and `app.auth.secret` to the Secret access key AWS gives you after creating the user.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -64,12 +64,11 @@ Next, create an IAM user at [https://console.aws.amazon.com/iam/home?region=us-e
 The access type should be `Programmatic access`.
 You can select `Add user to group` and create a new group. The group should have the following permissions:
 
-- `AWSElasticBeanstalkFullAccess`
+- `AdministratorAccess-AWSElasticBeanstalk`
 - `IAMFullAccess` This is used to create the roles and Instance Profiles needed by Elastic Beanstalk. After the first deploy, you can replace it with `IAMReadOnlyAccess`
 - `AWSCertificateManagerFullAccess` Used to create and manage SSL certificates for the app
 - `EC2InstanceConnect` is optional. Used when accessing a production Meteor shell or to connect your node developer tools to the app running in Elastic Beanstalk
-
-- ec2fullaccess
+- `AmazonEC2FullAccess`
 
 In your mup config, set `app.auth.id` to the Access Key ID, and `app.auth.secret` to the Secret access key AWS gives you after creating the user.
 


### PR DESCRIPTION
Hi, I was checking these steps and a few permissions names were incorrect.

This PR fixes those names.