### PR TITLE
Update mup version to fix MongoDB error

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-react": "^7.26.0",
     "gfm-code-blocks": "^1.0.0",
     "mocha": "^8.0.1",
-    "mup": "^1.5.4",
+    "mup": "^1.5.8",
     "shelljs": "^0.8.4"
   },
   "dependencies": {


### PR DESCRIPTION
I'm not sure if this is the root cause but I'm getting errors trying to connect to MongoDB.

Maybe we need mup up-to-date here?

It seems that this error was happening in mup versions less than 1.5.6 https://github.com/zodern/meteor-up/issues/1294#issuecomment-1038447237